### PR TITLE
fix: remove outer FunctionCallError in NFT metadata error matching

### DIFF
--- a/packages/frontend/src/services/NonFungibleTokens.js
+++ b/packages/frontend/src/services/NonFungibleTokens.js
@@ -75,7 +75,7 @@ export default class NonFungibleTokens {
                     }))
             );
         } catch (e) {
-            if (!e.toString().includes('FunctionCallError(MethodResolveError(MethodNotFound))')) {
+            if (!e.toString().includes('MethodResolveError(MethodNotFound)')) {
                 throw e;
             }
 


### PR DESCRIPTION
## Issues

<!-- List of issues this pull request is related to or solves  -->

## Changes description

<!-- Changes description -->

## Preview

<!-- Any information that helps to see the result of the changes: images, links, etc. -->

## Demo

<!-- If this is possible and these are complex changes, attach a demo for them  -->
